### PR TITLE
Added __execute_local_criteria() API for local evaluation

### DIFF
--- a/switcher_client/errors/__init__.py
+++ b/switcher_client/errors/__init__.py
@@ -10,3 +10,8 @@ class RemoteAuthError(RemoteError):
 class RemoteCriteriaError(RemoteError):
     def __init__(self, message):
         super().__init__(message)
+
+class LocalCriteriaError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)

--- a/switcher_client/lib/resolver.py
+++ b/switcher_client/lib/resolver.py
@@ -1,0 +1,41 @@
+from switcher_client.errors import LocalCriteriaError
+from switcher_client.lib.types import Config, Group, ResultDetail, Snapshot, SnapshotData
+from switcher_client.switcher_data import SwitcherData
+
+class Resolver:
+
+    @staticmethod
+    def check_criteria(snapshot: Snapshot | None, switcher: SwitcherData) -> ResultDetail:
+        if not snapshot:
+            raise LocalCriteriaError("Snapshot not loaded. Try to use 'Client.load_snapshot()'")
+
+        return Resolver.__check_domain(snapshot.data, switcher)
+    
+    @staticmethod
+    def __check_domain(data: SnapshotData, switcher: SwitcherData) -> ResultDetail:
+        if data.domain.activated is False:
+            return ResultDetail.disabled("Domain is disabled")
+
+        return Resolver.__check_group(data.domain.group, switcher)
+    
+    @staticmethod
+    def __check_group(groups: list[Group], switcher: SwitcherData) -> ResultDetail:
+        key = switcher._key
+
+        for group in groups:
+            config_found = next((c for c in group.config if c.key == key), None)
+
+            if config_found is not None:
+                if group.activated is False:
+                    return ResultDetail.disabled("Group disabled")
+                
+                return Resolver.__check_config(config_found, switcher)
+        
+        raise LocalCriteriaError(f"Config with key '{key}' not found in the snapshot")
+    
+    @staticmethod
+    def __check_config(config: Config, switcher: SwitcherData) -> ResultDetail:
+        if config.activated is False:
+            return ResultDetail.disabled("Config disabled")
+        
+        return ResultDetail.success()

--- a/switcher_client/lib/types.py
+++ b/switcher_client/lib/types.py
@@ -1,10 +1,18 @@
-from typing import Optional, List
+from typing import Optional
 
 class ResultDetail:
-    def __init__(self, result: bool, reason: str, metadata: dict):
+    def __init__(self, result: bool, reason: Optional[str], metadata: Optional[dict] = None):
         self.result = result
         self.reason = reason
         self.metadata = metadata
+
+    @staticmethod
+    def disabled(reason: str, metadata: Optional[dict] = None) -> 'ResultDetail':
+        return ResultDetail(result=False, reason=reason, metadata=metadata)
+
+    @staticmethod
+    def success(reason: str = "Success", metadata: Optional[dict] = None) -> 'ResultDetail':
+        return ResultDetail(result=True, reason=reason, metadata=metadata)
 
 class SnapshotData:
     def __init__(self):
@@ -12,35 +20,35 @@ class SnapshotData:
 
 class Domain:
     def __init__(self):
-        self.name: Optional[str] = None
+        self.name: str
         self.version: int = 0
-        self.activated: Optional[bool] = None
-        self.group: Optional[List[Group]] = None
+        self.activated: bool
+        self.group: list[Group]
 
 class Group:
     def __init__(self):
-        self.name: Optional[str] = None
-        self.activated: Optional[bool] = None
-        self.config: Optional[List[Config]] = None
+        self.name: str
+        self.activated: bool
+        self.config: list[Config]
 
 class Config:
     def __init__(self):
-        self.key: Optional[str] = None
-        self.activated: Optional[bool] = None
-        self.strategies: Optional[List[StrategyConfig]] = None
+        self.key: str
+        self.activated: bool
+        self.strategies: Optional[list[StrategyConfig]] = None
         self.relay: Optional[Relay] = None
 
 class StrategyConfig:
     def __init__(self):
-        self.strategy: Optional[str] = None
-        self.activated: Optional[bool] = None
-        self.operation: Optional[str] = None
-        self.values: Optional[List[str]] = None
+        self.strategy: str
+        self.activated: bool
+        self.operation: str
+        self.values: list[str]
 
 class Relay:
     def __init__(self):
-        self.type: Optional[str] = None
-        self.activated: Optional[bool] = None
+        self.type: str
+        self.activated: bool
 
 class Snapshot:
     def __init__(self, json_data: dict):
@@ -53,8 +61,8 @@ class Snapshot:
         """ Parse domain data from JSON """
 
         domain = Domain()
-        domain.name = domain_data.get('name')
-        domain.activated = domain_data.get('activated')
+        domain.name = domain_data.get('name', '')
+        domain.activated = domain_data.get('activated', False)
         domain.version = domain_data.get('version', 0)
         
         if 'group' in domain_data and domain_data['group']:
@@ -68,9 +76,9 @@ class Snapshot:
         """ Parse group data from JSON """
 
         group = Group()
-        group.name = group_data.get('name')
-        group.activated = group_data.get('activated')
-        
+        group.name = group_data.get('name', '')
+        group.activated = group_data.get('activated', False)
+
         if 'config' in group_data and group_data['config']:
             group.config = []
             for config_data in group_data['config']:
@@ -82,9 +90,9 @@ class Snapshot:
         """ Parse config data from JSON """
 
         config = Config()
-        config.key = config_data.get('key')
-        config.activated = config_data.get('activated')
-        
+        config.key = config_data.get('key', '')
+        config.activated = config_data.get('activated', False)
+
         if 'strategies' in config_data and config_data['strategies']:
             config.strategies = []
             for strategy_data in config_data['strategies']:
@@ -99,10 +107,10 @@ class Snapshot:
         """ Parse strategy data from JSON """
 
         strategy = StrategyConfig()
-        strategy.strategy = strategy_data.get('strategy')
-        strategy.activated = strategy_data.get('activated')
-        strategy.operation = strategy_data.get('operation')
-        strategy.values = strategy_data.get('values')
+        strategy.strategy = strategy_data.get('strategy', '')
+        strategy.activated = strategy_data.get('activated', False)
+        strategy.operation = strategy_data.get('operation', '')
+        strategy.values = strategy_data.get('values', [])
         
         return strategy
 
@@ -110,9 +118,9 @@ class Snapshot:
         """ Parse relay data from JSON """
 
         relay = Relay()
-        relay.type = relay_data.get('type')
-        relay.activated = relay_data.get('activated')
-        
+        relay.type = relay_data.get('type', '')
+        relay.activated = relay_data.get('activated', False)
+
         return relay
 
     def to_dict(self) -> dict:

--- a/switcher_client/switcher.py
+++ b/switcher_client/switcher.py
@@ -1,9 +1,11 @@
 from typing import Optional
 
 from switcher_client.lib.globals.global_context import Context
+from switcher_client.lib.globals.global_snapshot import GlobalSnapshot
 from switcher_client.lib.remote_auth import RemoteAuth
 from switcher_client.lib.globals import GlobalAuth
 from switcher_client.lib.remote import Remote
+from switcher_client.lib.resolver import Resolver
 from switcher_client.lib.types import ResultDetail
 from switcher_client.switcher_data import SwitcherData
 
@@ -11,6 +13,7 @@ class Switcher(SwitcherData):
     def __init__(self, context: Context, key: Optional[str] = None):
         super().__init__(key) 
         self._context = context
+        self.__validate_args(key)
 
     def prepare(self, key: Optional[str] = None):
         """ Checks API credentials and connectivity """
@@ -30,6 +33,9 @@ class Switcher(SwitcherData):
     
     def __submit(self) -> ResultDetail:
         """ Submit criteria for execution (local or remote) """
+        if (self._context.options.local):
+            return self.__execute_local_criteria()
+
         self.validate()
         response = self.__execute_remote_criteria()
 
@@ -70,3 +76,7 @@ class Switcher(SwitcherData):
         """ Execute remote criteria """
         token = GlobalAuth.get_token()
         return Remote.check_criteria(token, self._context, self)
+    
+    def __execute_local_criteria(self):
+        """ Execute local criteria """
+        return Resolver.check_criteria(GlobalSnapshot.snapshot(), self)

--- a/tests/snapshots/default_disabled.json
+++ b/tests/snapshots/default_disabled.json
@@ -1,0 +1,11 @@
+{
+    "data": {
+        "domain": {
+            "name": "Business",
+            "description": "Business description",
+            "activated": false,
+            "version": 1,
+            "group": []
+        }
+    }
+}

--- a/tests/test_switcher_local.py
+++ b/tests/test_switcher_local.py
@@ -1,0 +1,95 @@
+from switcher_client.client import Client, ContextOptions
+from switcher_client.errors import LocalCriteriaError
+
+def test_local():
+    """ Should use local Snapshot to evaluate the switcher """
+
+    # given
+    given_context('tests/snapshots')
+    snapshot_version = Client.load_snapshot()
+
+    switcher = Client.get_switcher()
+
+    # test
+    assert snapshot_version == 1
+    assert switcher.is_on('FF2FOR2022')
+
+def test_local_domain_disabled():
+    """ Should return disabled when domain is deactivated """
+
+    # given
+    given_context('tests/snapshots', environment='default_disabled')
+    snapshot_version = Client.load_snapshot()
+
+    switcher = Client.get_switcher()
+
+    # test
+    assert snapshot_version == 1
+    assert switcher.is_on('FEATURE') is False
+
+def test_local_group_disabled():
+    """ Should return disabled when group is deactivated """
+
+    # given
+    given_context('tests/snapshots')
+    snapshot_version = Client.load_snapshot()
+
+    switcher = Client.get_switcher()
+
+    # test
+    assert snapshot_version == 1
+    assert switcher.is_on('FF2FOR2040') is False
+
+def test_local_config_disabled():
+    """ Should return disabled when config is deactivated """
+
+    # given
+    given_context('tests/snapshots')
+    snapshot_version = Client.load_snapshot()
+
+    switcher = Client.get_switcher()
+
+    # test
+    assert snapshot_version == 1
+    assert switcher.is_on('FF2FOR2031') is False
+
+def test_local_no_key_found():
+    """ Should raise an error when no key is found in the snapshot """
+
+    # given
+    given_context('tests/snapshots')
+    snapshot_version = Client.load_snapshot()
+
+    switcher = Client.get_switcher()
+
+    # test
+    assert snapshot_version == 1
+    try:
+        switcher.is_on('INVALID_KEY')
+    except LocalCriteriaError as e:
+        assert str(e) == "Config with key 'INVALID_KEY' not found in the snapshot"
+
+def test_local_no_snapshot():
+    """ Should raise an error when no snapshot is loaded """
+
+    # given
+    given_context('tests/invalid_location')
+    switcher = Client.get_switcher()
+
+    # test
+    try:
+        switcher.is_on('FF2FOR2022')
+    except LocalCriteriaError as e:
+        assert str(e) == "Snapshot not loaded. Try to use 'Client.load_snapshot()'"
+
+# Helpers
+
+def given_context(snapshot_location: str, environment: str = 'default') -> None:
+    Client.build_context(
+        domain='Playground',
+        environment=environment,
+        options=ContextOptions(
+            local=True,
+            snapshot_location=snapshot_location
+        )
+    )


### PR DESCRIPTION
This pull request adds support for local criteria evaluation in the Switcher client, allowing feature flag checks to be performed using locally loaded snapshots instead of requiring remote API calls. It introduces a new resolver for local logic, improves error handling, and updates the data type definitions for stricter type safety. Comprehensive tests are also added to verify the new local evaluation logic.

**Local criteria evaluation and resolver:**

* Introduced the `Resolver` class in `lib/resolver.py` to evaluate feature flags locally using a loaded snapshot, including checks for domain, group, and config activation. Raises a custom `LocalCriteriaError` for missing or invalid data.
* Updated `Switcher` in `switcher.py` to route criteria checks through the new local resolver when the context specifies local evaluation, falling back to remote checks otherwise. [[1]](diffhunk://#diff-6344f95c6c8a70c5e5a4da805c8cb24d4b7fef5759e8035d67e35e72437e74e3R4-R16) [[2]](diffhunk://#diff-6344f95c6c8a70c5e5a4da805c8cb24d4b7fef5759e8035d67e35e72437e74e3R36-R38) [[3]](diffhunk://#diff-6344f95c6c8a70c5e5a4da805c8cb24d4b7fef5759e8035d67e35e72437e74e3R79-R82)

**Error handling improvements:**

* Added a new `LocalCriteriaError` exception for local evaluation errors, ensuring clear error reporting when snapshots are missing or keys are not found.

**Type safety and data model updates:**

* Made fields in `Domain`, `Group`, `Config`, `StrategyConfig`, and `Relay` non-optional and provided default values when parsing JSON, improving type safety and preventing issues with missing data. [[1]](diffhunk://#diff-e82a75bce5ccf5c2e2dd550f831a88c9d9193497c6fbb0fb25ec8f764b10ea77L1-R51) [[2]](diffhunk://#diff-e82a75bce5ccf5c2e2dd550f831a88c9d9193497c6fbb0fb25ec8f764b10ea77L56-R65) [[3]](diffhunk://#diff-e82a75bce5ccf5c2e2dd550f831a88c9d9193497c6fbb0fb25ec8f764b10ea77L71-R80) [[4]](diffhunk://#diff-e82a75bce5ccf5c2e2dd550f831a88c9d9193497c6fbb0fb25ec8f764b10ea77L85-R94) [[5]](diffhunk://#diff-e82a75bce5ccf5c2e2dd550f831a88c9d9193497c6fbb0fb25ec8f764b10ea77L102-R122)
* Added static methods to `ResultDetail` for easily creating success and disabled results.