### PR TITLE
chore(tests): added integrated tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,5 +11,6 @@ pylint = "==4.0.5"
 pytest = "==9.0.2"
 pytest-cov = "==7.1.0"
 pytest-httpx = "==0.36.0"
+python-dotenv = "==1.2.2"
 typing-extensions = "4.15.0"
 switcher-client = {file = ".", editable = true}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f7e69a1b6bf8d827e6cde44432eb7c3664cc4be01a6a2c94710235fe62b9657"
+            "sha256": "55bb88928ba4835b696ca7677b8a1b6fe12e942f2940ea8b33da700e0bcb1c1e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -396,6 +396,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==0.36.0"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a",
+                "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==1.2.2"
         },
         "switcher-client": {
             "editable": true,

--- a/tests/playground/index.py
+++ b/tests/playground/index.py
@@ -1,11 +1,16 @@
 import threading
 import time
+import os
 
-from .util import monitor_run
+from dotenv import load_dotenv
+
+from util import monitor_run
 from switcher_client.lib.globals.global_context import DEFAULT_ENVIRONMENT
 from switcher_client.lib.globals.global_snapshot import LoadSnapshotOptions
 from switcher_client import Client, ContextOptions, WatchSnapshotCallback
 
+load_dotenv()
+API_KEY = os.getenv('SWITCHER_API_KEY')
 SWITCHER_KEY = 'CLIENT_PYTHON_FEATURE'
 LOOP = True
 
@@ -13,7 +18,7 @@ def setup_context(options: ContextOptions = ContextOptions(), environment = DEFA
     Client.build_context(
         domain='Switcher API',
         url='https://api.switcherapi.com',
-        api_key='[API_KEY]',
+        api_key=API_KEY,
         component='switcher-client-python',
         environment=environment,
         options=options
@@ -112,7 +117,7 @@ def uc_watch_snapshot():
 
 try:
     # Replace with use case
-    uc_watch_snapshot()
+    uc_simple_api_call()
     while LOOP:
         time.sleep(1)
 except KeyboardInterrupt:

--- a/tests/test_switcher_integration.py
+++ b/tests/test_switcher_integration.py
@@ -1,0 +1,71 @@
+import os
+
+from dotenv import load_dotenv
+
+from switcher_client.client import Client
+from switcher_client.lib.globals.global_context import ContextOptions
+from switcher_client.lib.globals.global_snapshot import LoadSnapshotOptions
+
+load_dotenv()
+API_KEY = os.getenv('SWITCHER_API_KEY')
+WARN_SKIP = 'API key not found. Please set the SWITCHER_API_KEY environment variable.'
+
+def test_is_on():
+    """ Should call the remote API with success """
+
+    if not API_KEY:
+        print(WARN_SKIP)
+        return
+
+    # given
+    given_context()
+    switcher = Client.get_switcher('CLIENT_PYTHON_FEATURE')
+
+    # test
+    response_detail = switcher.is_on_with_details()
+    assert response_detail is not None
+
+def test_load_snapshot():
+    """ Should load the snapshot from the remote API with success """
+
+    if not API_KEY:
+        print(WARN_SKIP)
+        return
+
+    # given
+    given_context(options=ContextOptions(local=True))
+
+    # test
+    snapshot = Client.load_snapshot(options=LoadSnapshotOptions(fetch_remote=True))
+    switcher = Client.get_switcher('CLIENT_PYTHON_FEATURE')
+    response_detail = switcher.is_on_with_details()
+
+    assert snapshot is not None
+    assert response_detail is not None
+
+def test_check_switcher_availability():
+    """ Should check the switcher availability with success """
+
+    if not API_KEY:
+        print(WARN_SKIP)
+        return
+
+    # given
+    given_context()
+
+    # test
+    try:
+        Client.check_switchers(['CLIENT_PYTHON_FEATURE'])
+    except Exception as e:
+        assert False, f'check_switchers should not raise an exception, but got: {e}'
+
+# Helpers
+
+def given_context(options=ContextOptions()):
+    Client.build_context(
+        url='https://api.switcherapi.com',
+        api_key=API_KEY,
+        domain='Switcher API',
+        component='switcher-client-python',
+        options=options
+    )


### PR DESCRIPTION
This pull request introduces environment variable support for API keys using `python-dotenv`, and adds new integration tests for the Switcher client. The main changes include updating dependencies, refactoring test setup to use environment variables, and implementing integration tests that interact with the remote API.

**Environment variable and dependency updates:**

* Added `python-dotenv` to the `Pipfile` to enable loading environment variables from a `.env` file.
* Updated test setup in `tests/playground/index.py` to load the API key from the environment using `dotenv`, replacing the hardcoded value with `os.getenv('SWITCHER_API_KEY')`.

**Testing improvements:**

* Added a new file `tests/test_switcher_integration.py` with integration tests for key Switcher client functionalities, including API calls, snapshot loading, and switcher availability checks. These tests use the API key from the environment and skip execution if it is not set.
* Changed the default test use case in `tests/playground/index.py` to use `uc_simple_api_call()` instead of `uc_watch_snapshot()`.