### PR TITLE
fix: packages compatibity issues found for Python < 3.12

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,8 @@
 [run]
-omit = 
+omit =
     switcher_client/lib/utils/timed_match/worker.py
-    switcher_client/version.py
+    switcher_client/lib/compat.py,
+    switcher_client/version.py,
     */tests/*
     */test_*
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,7 +34,7 @@ jobs:
         run: pipenv run pytest -v --cov=./switcher_client --cov-report xml --cov-config=.coveragerc
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v7.0.0
+        uses: sonarsource/sonarqube-scan-action@v7.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Lint
         run: pipenv run python -m pylint switcher_client
-      
+
       - name: Test
         run: pipenv run pytest -v --cov=./switcher_client --cov-report xml --cov-config=.coveragerc
 
@@ -62,8 +62,5 @@ jobs:
           pip install pipenv
           pipenv install --dev
 
-      - name: Lint
-        run: pipenv run python -m pylint switcher_client
-      
       - name: Test
         run: pipenv run pytest -v

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -47,7 +47,7 @@ jobs:
         run: pipenv run pytest -v --cov=./switcher_client --cov-report xml
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v7.0.0
+        uses: sonarsource/sonarqube-scan-action@v7.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,6 +12,10 @@ on:
         description: 'Operating System (ubuntu-20.04, ubuntu-latest, windows-latest)'
         required: true
         default: 'ubuntu-latest'
+      skip-lint:
+        description: 'Skip linting step'
+        required: false
+        default: 'false'
 
 jobs:
   build-test:
@@ -35,7 +39,8 @@ jobs:
           pipenv install --dev
 
       - name: Lint
+        if: ${{ github.event.inputs.skip-lint != 'true' }}
         run: pipenv run python -m pylint switcher_client
-      
+
       - name: Test
         run: pipenv run pytest -v

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 httpx = {extras = ["http2"], version = "==0.28.1"}
+typing_extensions = {version = ">=4.0", markers = "python_version < '3.11'"}
 
 [dev-packages]
 exceptiongroup = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 httpx = {extras = ["http2"], version = "==0.28.1"}
 
 [dev-packages]
+exceptiongroup = "*"
 pylint = "==4.0.5"
 pytest = "==9.0.2"
 pytest-cov = "==7.1.0"

--- a/Pipfile
+++ b/Pipfile
@@ -8,9 +8,9 @@ httpx = {extras = ["http2"], version = "==0.28.1"}
 
 [dev-packages]
 pylint = "==4.0.5"
-pytest = "==9.0.3"
+pytest = "==9.0.2"
 pytest-cov = "==7.1.0"
-pytest-httpx = "==0.36.2"
+pytest-httpx = "==0.36.0"
 python-dotenv = "==1.2.2"
 typing-extensions = "4.15.0"
 switcher-client = {file = ".", editable = true}

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 httpx = {extras = ["http2"], version = "==0.28.1"}
-typing-extensions = {version = "==4.15.0", markers = "python_version < '3.11'"}
+typing-extensions = {version = "==4.15.0", markers = "python_version <= '3.12'"}
 
 [dev-packages]
 exceptiongroup = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 httpx = {extras = ["http2"], version = "==0.28.1"}
-typing_extensions = {version = ">=4.0", markers = "python_version < '3.11'"}
+typing-extensions = {version = "==4.15.0", markers = "python_version < '3.11'"}
 
 [dev-packages]
 exceptiongroup = "*"
@@ -15,5 +15,4 @@ pytest = "==9.0.2"
 pytest-cov = "==7.1.0"
 pytest-httpx = "==0.36.0"
 python-dotenv = "==1.2.2"
-typing-extensions = "4.15.0"
 switcher-client = {file = ".", editable = true}

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ httpx = {extras = ["http2"], version = "==0.28.1"}
 
 [dev-packages]
 exceptiongroup = "*"
+tomli = "*"
 pylint = "==4.0.5"
 pytest = "==9.0.2"
 pytest-cov = "==7.1.0"

--- a/Pipfile
+++ b/Pipfile
@@ -11,8 +11,8 @@ typing-extensions = {version = "==4.15.0", markers = "python_version <= '3.12'"}
 exceptiongroup = "*"
 tomli = "*"
 pylint = "==4.0.5"
-pytest = "==9.0.2"
+pytest = "==9.0.3"
 pytest-cov = "==7.1.0"
-pytest-httpx = "==0.36.0"
+pytest-httpx = "==0.36.2"
 python-dotenv = "==1.2.2"
 switcher-client = {file = ".", editable = true}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e5d4d4f0b1d70407c41791527d986e3b2133c55ae84cbd0255b521e3367a347f"
+            "sha256": "09540cebd003e76c28411766b469baa8dfc9656847344d1d0e67162219f64ba4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -88,6 +88,10 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==3.11"
+        },
+        "typing_extensions": {
+            "markers": "python_version < '3.11'",
+            "version": "==>=4.0"
         }
     },
     "develop": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b179bf84b8a5bb7cb4ef0e723a93894612f804b10009ee2b626703b0840c1da2"
+            "sha256": "55bb88928ba4835b696ca7677b8a1b6fe12e942f2940ea8b33da700e0bcb1c1e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -331,19 +331,19 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
-                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
+                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
+                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.1"
+            "version": "==26.0"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
-                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
+                "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934",
+                "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.9.6"
+            "version": "==4.9.4"
         },
         "pluggy": {
             "hashes": [
@@ -372,12 +372,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9",
-                "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
+                "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b",
+                "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==9.0.3"
+            "version": "==9.0.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -390,12 +390,12 @@
         },
         "pytest-httpx": {
             "hashes": [
-                "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356",
-                "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22"
+                "sha256:9edb66a5fd4388ce3c343189bc67e7e1cb50b07c2e3fc83b97d511975e8a831b",
+                "sha256:bd4c120bb80e142df856e825ec9f17981effb84d159f9fa29ed97e2357c3a9c8"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==0.36.2"
+            "version": "==0.36.0"
         },
         "python-dotenv": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e647ecf5c7627582e30ada5dc2d99c95bd324aacc9f46636b0d6f24a153c0fd2"
+            "sha256": "e5d4d4f0b1d70407c41791527d986e3b2133c55ae84cbd0255b521e3367a347f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -418,6 +418,60 @@
         "switcher-client": {
             "editable": true,
             "file": "."
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853",
+                "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe",
+                "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5",
+                "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d",
+                "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd",
+                "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26",
+                "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54",
+                "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6",
+                "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c",
+                "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a",
+                "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd",
+                "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f",
+                "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5",
+                "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9",
+                "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662",
+                "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9",
+                "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1",
+                "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585",
+                "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e",
+                "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c",
+                "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41",
+                "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f",
+                "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085",
+                "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15",
+                "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7",
+                "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c",
+                "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36",
+                "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076",
+                "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac",
+                "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8",
+                "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232",
+                "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece",
+                "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a",
+                "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897",
+                "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d",
+                "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4",
+                "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917",
+                "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396",
+                "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a",
+                "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc",
+                "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba",
+                "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f",
+                "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257",
+                "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30",
+                "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf",
+                "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9",
+                "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2.4.1"
         },
         "tomlkit": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "55bb88928ba4835b696ca7677b8a1b6fe12e942f2940ea8b33da700e0bcb1c1e"
+            "sha256": "e647ecf5c7627582e30ada5dc2d99c95bd324aacc9f46636b0d6f24a153c0fd2"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -246,6 +246,15 @@
             "markers": "python_version >= '3.9'",
             "version": "==0.4.1"
         },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219",
+                "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.1"
+        },
         "h11": {
             "hashes": [
                 "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1",
@@ -331,19 +340,19 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
-                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
+                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
+                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.0"
+            "version": "==26.1"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934",
-                "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"
+                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
+                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.9.4"
+            "version": "==4.9.6"
         },
         "pluggy": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "09540cebd003e76c28411766b469baa8dfc9656847344d1d0e67162219f64ba4"
+            "sha256": "9cf1dd24cc4e5e15c8fbf174e62b8a5898f053c68f0d06ba545a84517f498fae"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -89,9 +89,13 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.11"
         },
-        "typing_extensions": {
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
             "markers": "python_version < '3.11'",
-            "version": "==>=4.0"
+            "version": "==4.15.0"
         }
     },
     "develop": {
@@ -484,15 +488,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==0.14.0"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
-                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==4.15.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9cf1dd24cc4e5e15c8fbf174e62b8a5898f053c68f0d06ba545a84517f498fae"
+            "sha256": "5cb0b6768d6b81c3536c376730e3687436f6c779e75094a0cc7eb93770dbbc13"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -94,7 +94,7 @@
                 "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
                 "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version <= '3.12'",
             "version": "==4.15.0"
         }
     },
@@ -389,12 +389,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b",
-                "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"
+                "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9",
+                "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==9.0.2"
+            "version": "==9.0.3"
         },
         "pytest-cov": {
             "hashes": [
@@ -407,12 +407,12 @@
         },
         "pytest-httpx": {
             "hashes": [
-                "sha256:9edb66a5fd4388ce3c343189bc67e7e1cb50b07c2e3fc83b97d511975e8a831b",
-                "sha256:bd4c120bb80e142df856e825ec9f17981effb84d159f9fa29ed97e2357c3a9c8"
+                "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356",
+                "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==0.36.0"
+            "version": "==0.36.2"
         },
         "python-dotenv": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A Python SDK for Switcher API
 
 [![Master CI](https://github.com/switcherapi/switcher-client-py/actions/workflows/master.yml/badge.svg)](https://github.com/switcherapi/switcher-client-py/actions/workflows/master.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=switcherapi_switcher-client-py&metric=alert_status)](https://sonarcloud.io/dashboard?id=switcherapi_switcher-client-py)
-[![Known Vulnerabilities](https://snyk.io/test/github/switcherapi/switcher-client-py/badge.svg)](https://snyk.io/test/github/switcherapi/switcher-client-py)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Slack: Switcher-HQ](https://img.shields.io/badge/slack-@switcher/hq-blue.svg?logo=slack)](https://switcher-hq.slack.com/)
 
@@ -165,7 +164,7 @@ switcher = Client.get_switcher()
 
 - **ReDoS Protection**: Built-in ReDoS attack prevention with regex safety features
 - **Time Limits**: Configurable timeouts prevent long-running regex operations
-- **Certificate Support**: Use custom certificates for secure API connections  
+- **Certificate Support**: Use custom certificates for secure API connections
 
 ## Usage Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "switcher_client"
 description = "Switcher Client SDK for Python"
 dynamic = ["version", "readme"]
-dependencies = ["httpx[http2]>=0.28.1"]
+dependencies = [
+	"httpx[http2]>=0.28.1",
+	"typing_extensions>=4.0; python_version < '3.11'",
+]
 authors = [{name='Roger Floriano (petruki)', email='switcher.project@gmail.com'}]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Switcher Client SDK for Python"
 dynamic = ["version", "readme"]
 dependencies = [
 	"httpx[http2]>=0.28.1",
-	"typing_extensions>=4.0; python_version < '3.11'",
+	"typing_extensions>=4.0; python_version <= '3.12'",
 ]
 authors = [{name='Roger Floriano (petruki)', email='switcher.project@gmail.com'}]
 license = "MIT"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,4 +8,4 @@ sonar.sources=switcher_client
 sonar.tests=tests
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.14
-sonar.exclusions=**/tests/**,**/switcher_client/version.py,**/switcher_client/lib/utils/timed_match/worker.py,**/switcher_client/lib/utils/timed_match/__init__.py
+sonar.exclusions=**/tests/**,**/switcher_client/version.py,**/switcher_client/lib/utils/timed_match/worker.py,**/switcher_client/lib/utils/timed_match/__init__.py,**/switcher_client/lib/compat.py

--- a/switcher_client/errors/__init__.py
+++ b/switcher_client/errors/__init__.py
@@ -13,12 +13,12 @@ class RemoteCriteriaError(RemoteError):
 class RemoteSwitcherError(RemoteError):
     """ Raised when there is a switcher error with the remote service """
     def __init__(self, not_found: list):
-        super().__init__(f'{', '.join(not_found)} not found')
+        super().__init__(f'{", ".join(not_found)} not found')
 
 class LocalSwitcherError(Exception):
     """ Raised when there is a switcher error with the local service """
     def __init__(self, not_found: list):
-        self.message = f'{', '.join(not_found)} not found'
+        self.message = f'{", ".join(not_found)} not found'
         super().__init__(self.message)
 
 class LocalCriteriaError(Exception):

--- a/switcher_client/lib/compat.py
+++ b/switcher_client/lib/compat.py
@@ -1,0 +1,8 @@
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+__all__ = ['Self']

--- a/switcher_client/switcher_data.py
+++ b/switcher_client/switcher_data.py
@@ -1,11 +1,12 @@
 # pylint: disable=redefined-builtin
-from dataclasses import dataclass
 import json
 
+from dataclasses import dataclass
 from datetime import datetime
 from abc import ABCMeta
-from typing import Optional, Self, Union
+from typing import Optional, Union
 
+from switcher_client.lib.compat import Self
 from switcher_client.lib.utils import get
 from switcher_client.lib.globals.global_context import Context
 from switcher_client.lib.snapshot import StrategiesType


### PR DESCRIPTION
This pull request introduces several improvements and maintenance updates across the codebase and CI configuration. The most notable changes are the addition of a compatibility module for the `Self` type, enhancements to dependency management for Python versions, improvements to workflow flexibility, and minor bug fixes.

**Python compatibility and dependency management:**
- Added a new module `switcher_client/lib/compat.py` to provide a version-agnostic import for the `Self` type, ensuring compatibility across Python versions.
- Updated `pyproject.toml` and `Pipfile` to conditionally include `typing-extensions` for Python ≤ 3.12, and adjusted dev dependencies for better environment setup. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L9-R12) [[2]](diffhunk://#diff-230078d672f10d17463a8a6265cad825b790885898256a3365be90685caac58dR8-L15)
- Updated imports in `switcher_client/switcher_data.py` to use `Self` from the new compatibility module.

**CI/CD workflow improvements:**
- Upgraded the SonarCloud GitHub Action to v7.1.0 in both `master.yml` and `sonar.yml` for improved scanning capabilities. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L37-R37) [[2]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L50-R50)
- Added a `skip-lint` input to the `staging.yml` workflow, allowing developers to optionally skip linting during CI runs. [[1]](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR15-R18) [[2]](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bR42)
- Removed the linting step from the `master.yml` workflow for streamlined testing.

**Test coverage and code quality configuration:**
- Updated `.coveragerc` and `sonar-project.properties` to exclude the new compatibility module from coverage and SonarCloud analysis. [[1]](diffhunk://#diff-834e9b406d74791ffbafaeec9cc894082cea9739bc347b6ff9f72312c92ebc79L4-R5) [[2]](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL11-R11)

**Bug fixes and documentation:**
- Fixed string formatting in error messages in `switcher_client/errors/__init__.py` for correct output.
- Removed the Snyk badge from `README.md` for a cleaner project overview.