### PR TITLE
fix: removed duplicated classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ requires-python = ">=3.9"
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
 	"Intended Audience :: Developers",
-	"License :: OSI Approved :: MIT License",
 	"Programming Language :: Python",
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This pull request makes a minor update to the `pyproject.toml` file by removing the MIT License classifier from the list of project classifiers.

- Cause
Since license = "MIT" is already set as a SPDX expression (PEP 639), the License :: OSI Approved :: MIT License classifier is now redundant and rejected by newer setuptools.

- Solution
Removed the License :: OSI Approved :: MIT License classifier. Since license = "MIT" already provides the SPDX expression per PEP 639, the old classifier is no longer valid and was causing the build failure with newer setuptools.