### PR TITLE
feat: added Client.assume for is_on Switcher evaluation

### DIFF
--- a/switcher_client/client.py
+++ b/switcher_client/client.py
@@ -1,5 +1,6 @@
 from typing import Optional, Callable
 
+from switcher_client.lib.bypasser import Bypasser, Key
 from switcher_client.lib.globals.global_auth import GlobalAuth
 from switcher_client.lib.globals.global_snapshot import GlobalSnapshot, LoadSnapshotOptions
 from switcher_client.lib.globals.global_context import Context, ContextOptions, DEFAULT_ENVIRONMENT
@@ -248,6 +249,16 @@ class Client:
         It is usually used when throttle and silent mode are enabled.
         """
         ExecutionLogger.subscribe_notify_error(callback)
+
+    @staticmethod
+    def assume(key: str) -> Key:
+        """ Force a switcher value to return a given value by calling one of both methods - true() false() """
+        return Bypasser.assume(key)
+
+    @staticmethod
+    def forget(key: str) -> None:
+        """ Remove forced value from a switcher """
+        Bypasser.forget(key)
 
     @staticmethod
     def _is_check_snapshot_available(fetch_remote = False) -> bool:

--- a/switcher_client/lib/bypasser/__init__.py
+++ b/switcher_client/lib/bypasser/__init__.py
@@ -1,0 +1,7 @@
+from switcher_client.lib.bypasser.bypasser import Bypasser
+from switcher_client.lib.bypasser.key import Key
+
+__all__ = [
+    'Bypasser',
+    'Key',
+]

--- a/switcher_client/lib/bypasser/bypasser.py
+++ b/switcher_client/lib/bypasser/bypasser.py
@@ -1,0 +1,33 @@
+from switcher_client.lib.bypasser.key import Key
+
+class Bypasser:
+    """
+    Bypasser allows to force a switcher value to return a given value by calling one of both methods - true() false()
+    """
+
+    _bypassed_keys = []
+
+    @staticmethod
+    def assume(key: str) -> Key:
+        # Remove previous forced value if exists to avoid conflicts
+        Bypasser.forget(key)
+
+        new_key = Key(key)
+        Bypasser._bypassed_keys.append(new_key)
+        return new_key
+
+    @staticmethod
+    def forget(key: str) -> None:
+        """ Remove forced value from a switcher """
+        key_stored = Bypasser.search_key(key)
+        if key_stored is not None:
+            Bypasser._bypassed_keys.remove(key_stored)
+
+    @staticmethod
+    def search_key(key: str) -> Key | None:
+        """ Search for key registered via 'assume' """
+        for bypassed_key in Bypasser._bypassed_keys:
+            if bypassed_key.key == key:
+                return bypassed_key
+
+        return None

--- a/switcher_client/lib/bypasser/key.py
+++ b/switcher_client/lib/bypasser/key.py
@@ -1,0 +1,20 @@
+from switcher_client.lib.types import ResultDetail
+
+class Key:
+    """ Key record used to store key response when bypassing criteria execution """
+
+    def __init__(self, key: str):
+        self._key = key
+        self._result = None
+
+    def true(self):
+        """ Force a switcher value to return true """
+        self._result = True
+
+    def get_response(self, input_list: list[str]) -> ResultDetail:
+        return ResultDetail.create(result=True, reason=f"Forced to '{self._result}' - input: {input_list}")
+
+    @property
+    def key(self):
+        """ Get the key of the switcher """
+        return self._key

--- a/switcher_client/switcher.py
+++ b/switcher_client/switcher.py
@@ -2,6 +2,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Optional
 
+from switcher_client.lib.bypasser import Bypasser
 from switcher_client.lib.globals.global_context import Context
 from switcher_client.lib.globals.global_snapshot import GlobalSnapshot
 from switcher_client.lib.remote_auth import RemoteAuth
@@ -50,6 +51,11 @@ class Switcher(SwitcherData):
         """ Execute criteria """
         self._show_details = False
         self._validate_args(key, details=False)
+
+        # verify if query from Bypasser
+        bypass_key = Bypasser.search_key(self._key)
+        if bypass_key is not None:
+            return bypass_key.get_response(self._input).result
 
         # try get cached result
         cached_result = self._try_cached_result()

--- a/tests/test_switcher_stub.py
+++ b/tests/test_switcher_stub.py
@@ -1,0 +1,28 @@
+from tests.test_switcher_integration import given_context
+
+from switcher_client.client import Client, ContextOptions
+
+context_options_local = ContextOptions(snapshot_location='tests/snapshots', local=True, logger=True)
+
+class TestSwitcherStub:
+    """ Test suite for SwitcherStub (Bypasser) - Client.assume() """
+
+    key = 'FF2FOR2020'
+
+    def setup_method(self):
+        given_context(options=context_options_local)
+        Client.load_snapshot()
+
+    def teardown_method(self):
+        Client.forget(self.key)
+
+    def test_switcher_stub_result(self):
+        """ Should bypass Switcher evaluation and return the stubbed result """
+
+        # given
+        switcher = Client.get_switcher(self.key)
+
+        # test
+        Client.assume(self.key).true()
+
+        assert switcher.is_on()


### PR DESCRIPTION
This pull request introduces a new "Bypasser" feature that allows developers to force switcher values for testing or stubbing purposes. The main changes add the ability to assume (force) or forget (remove) a value for a given switcher key, integrate this logic into the switcher evaluation flow, and provide tests for the new functionality.

Bypasser feature implementation:

* Added the `Bypasser` class and `Key` class, which allow forcing a switcher value and retrieving or removing forced values (`switcher_client/lib/bypasser/bypasser.py`, `switcher_client/lib/bypasser/key.py`, `switcher_client/lib/bypasser/__init__.py`) [[1]](diffhunk://#diff-cf2b315c0e563c5fb996c1e6e0bc15476b9b07809ef91df232c611ac769dc8e9R1-R33) [[2]](diffhunk://#diff-56acd65304a64b2907127204a4946e76ba66b0cbdf958c58763f98cb47a40c4fR1-R20) [[3]](diffhunk://#diff-928e0fd6a666b6e911ae56e97570a8b036645b0987ea34411280f492dbc82c1fR1-R7).
* Exposed `assume` and `forget` methods in the `Client` class to set or remove forced values for switchers (`switcher_client/client.py`).
* Updated the switcher evaluation logic in `Switcher.is_on()` to return the forced value if present (`switcher_client/switcher.py`).

Testing:

* Added a test suite to verify that forced switcher values override normal evaluation (`tests/test_switcher_stub.py`).

Imports and integration:

* Updated imports in `client.py` and `switcher.py` to include the new `Bypasser` module (`switcher_client/client.py`, `switcher_client/switcher.py`) [[1]](diffhunk://#diff-6cd9caf806d7ec0e35fcce096ce6434e06beca4d279f2204b6bb55c57de5cde4R3) [[2]](diffhunk://#diff-6344f95c6c8a70c5e5a4da805c8cb24d4b7fef5759e8035d67e35e72437e74e3R5).