### PR TITLE
feat: added support to watch snapshot while loading file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,4 @@
 [run]
-relative_files = True
 omit =
     switcher_client/lib/utils/timed_match/worker.py
     switcher_client/lib/compat.py,

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+relative_files = True
 omit =
     switcher_client/lib/utils/timed_match/worker.py
     switcher_client/lib/compat.py,

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,7 +34,7 @@ jobs:
         run: pipenv run pytest -v --cov=./switcher_client --cov-report xml --cov-config=.coveragerc
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v7.1.0
+        uses: sonarsource/sonarqube-scan-action@v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -47,7 +47,7 @@ jobs:
         run: pipenv run pytest -v --cov=./switcher_client --cov-report xml
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v7.1.0
+        uses: sonarsource/sonarqube-scan-action@v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/README.md
+++ b/README.md
@@ -288,11 +288,21 @@ switcher.remote().is_on('FEATURE01')
 
 ### Loading Snapshots
 
-Load configuration snapshots from the API for local/offline usage:
+Load snapshots from the API or local files:
 
 ```python
-# Download and save snapshot from API
+# Load snapshot from local file
 Client.load_snapshot()
+```
+
+```python
+# Load snapshot from API with fetch_remote option
+Client.load_snapshot(LoadSnapshotOptions(fetch_remote=True))
+```
+
+```python
+# Load snapshot with watch option to update the client in real-time when file changes
+Client.load_snapshot(LoadSnapshotOptions(watch_snapshot=True))
 ```
 
 ### Version Management

--- a/switcher_client/client.py
+++ b/switcher_client/client.py
@@ -141,6 +141,9 @@ class Client:
         if Client._is_check_snapshot_available(snapshot_options.fetch_remote):
             Client.check_snapshot()
 
+        if snapshot_options.watch_snapshot:
+            Client.watch_snapshot()
+
         return Client.snapshot_version()
 
     @staticmethod

--- a/tests/test_client_watch_snapshot.py
+++ b/tests/test_client_watch_snapshot.py
@@ -6,6 +6,7 @@ from tests.helpers import given_context
 
 from switcher_client.client import Client, ContextOptions
 from switcher_client.lib.snapshot_watcher import SnapshotWatcher, WatchSnapshotCallback
+from switcher_client.lib.globals.global_snapshot import LoadSnapshotOptions
 
 context_options_local = ContextOptions(local=True, snapshot_location='tests/snapshots/temp')
 async_error = None
@@ -53,6 +54,31 @@ class TestClientWatchSnapshot:
         if verified:
             assert switcher.is_on() == False
             assert self.async_error is None
+        else:
+            print("Warning: Snapshot watcher did not detect the change within the time limit")
+
+    def test_watch_snapshot_from_load_snapshot(self):
+        """ Should watch the snapshot file when load_snapshot is called with watch_snapshot option """
+
+        fixture_env = 'default_load_1'
+        fixture_env_file_modified = 'tests/snapshots/default_load_2.json'
+        fixture_location = 'tests/snapshots/temp'
+
+        # given
+        modify_fixture_snapshot(fixture_location, fixture_env, f'tests/snapshots/{fixture_env}.json')
+        given_context(options=context_options_local, environment=fixture_env)
+
+        # test
+        Client.load_snapshot(LoadSnapshotOptions(watch_snapshot=True))
+        switcher = Client.get_switcher('FF2FOR2030')
+
+        assert switcher.is_on()
+        modify_fixture_snapshot(fixture_location, fixture_env, fixture_env_file_modified)
+
+        # then
+        verified = verify_util(30, lambda: switcher.is_on() == False)
+        if verified:
+            assert switcher.is_on() == False
         else:
             print("Warning: Snapshot watcher did not detect the change within the time limit")
 


### PR DESCRIPTION
This pull request introduces support for watching snapshot files for changes when loading them, updates documentation to reflect the new snapshot loading options, and makes minor configuration and workflow updates. The main focus is on enhancing the snapshot loading functionality to allow real-time updates when the snapshot file changes.

**Enhancements to snapshot loading and watching:**

* Added support for watching the snapshot file for changes when calling `Client.load_snapshot` with the `watch_snapshot` option, triggering automatic updates when the file changes (`switcher_client/client.py`, `LoadSnapshotOptions`).
* Updated the documentation in `README.md` to explain the new options for loading snapshots, including how to use the `fetch_remote` and `watch_snapshot` parameters.
* Added a new test case to verify that using `Client.load_snapshot(LoadSnapshotOptions(watch_snapshot=True))` properly watches the snapshot file and updates the client when the file changes (`tests/test_client_watch_snapshot.py`).
* Imported `LoadSnapshotOptions` in the test file to support the new test case (`tests/test_client_watch_snapshot.py`).

**Configuration and workflow updates:**

* Updated SonarCloud scan action to version 8.0.0 in both `master.yml` and `sonar.yml` workflow files for improved CI/CD integration. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L37-R37) [[2]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L50-R50)
* Set `relative_files = True` in `.coveragerc` to improve coverage reporting.