### PR TITLE
fix: wrong value strategy EQUAL/NOT_EQUAL operations eval

### DIFF
--- a/switcher_client/lib/snapshot.py
+++ b/switcher_client/lib/snapshot.py
@@ -64,9 +64,10 @@ def _process_value(operation: str, values: list, input_value: str) -> Optional[b
         case OperationsType.NOT_EXIST.value:
             return input_value not in values
         case OperationsType.EQUAL.value:
-            return input_value in values
+            return input_value == values[0]
         case OperationsType.NOT_EQUAL.value:
-            return input_value not in values
+            result = [element for element in values if element == input_value]
+            return len(result) == 0
 
 # pylint: disable=too-many-return-statements
 def _process_numeric(operation: str, values: list, input_value: str) -> Optional[bool]:


### PR DESCRIPTION
This pull request updates the logic for handling equality and inequality operations in the `_process_value` function in `snapshot.py`. The changes make the equality check stricter and the inequality check more explicit.

**Logic updates for value comparison:**

* Changed the equality operation to check if `input_value` is exactly equal to the first element of `values`, instead of checking for membership in the list.
* Updated the inequality operation to explicitly return `True` only if `input_value` does not match any element in `values`, making the logic more precise.