### PR TITLE
chore(ci): bump actions checkout@v7, upload-artifact@v7, setup-miniconda@v4

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -33,7 +33,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -74,10 +74,10 @@ jobs:
       url: https://anaconda.org/switcherapi/switcher-client
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Miniconda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v4
       with:
         auto-update-conda: true
         python-version: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -51,7 +51,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -90,10 +90,10 @@ jobs:
       url: https://anaconda.org/switcherapi/switcher-client
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Set up Miniconda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v4
       with:
         auto-update-conda: true
         python-version: "3.12"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,7 +28,7 @@ jobs:
           core.setOutput('base_ref', pr.data.base.ref);
           core.setOutput('head_sha', pr.data.head.sha);
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         ref: ${{ steps.pr.outputs.head_sha }}
         fetch-depth: 0

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest versions of key actions, improving security, reliability, and compatibility. The main changes are version bumps for `actions/checkout`, `actions/upload-artifact`, and `conda-incubator/setup-miniconda` across multiple workflow files.

**Workflow action version updates:**

* Updated `actions/checkout` from `v6` to `v7` in `.github/workflows/master.yml`, `.github/workflows/release.yml`, `.github/workflows/release-test.yml`, `.github/workflows/sonar.yml`, and `.github/workflows/staging.yml` for all checkout steps. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L16-R16) [[2]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L53-R53) [[3]](diffhunk://#diff-cfb5fad94da0d964cbd2b402415839cc0c8e79a9ce5ae58586f5c8becb0d938dL22-R22) [[4]](diffhunk://#diff-cfb5fad94da0d964cbd2b402415839cc0c8e79a9ce5ae58586f5c8becb0d938dL77-R80) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19) [[6]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L40-R40) [[7]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L93-R96) [[8]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L31-R31) [[9]](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bL27-R27)
* Updated `actions/upload-artifact` from `v6` to `v7` in `.github/workflows/release-test.yml` and `.github/workflows/release.yml`. [[1]](diffhunk://#diff-cfb5fad94da0d964cbd2b402415839cc0c8e79a9ce5ae58586f5c8becb0d938dL36-R36) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R54)
* Updated `conda-incubator/setup-miniconda` from `v3` to `v4` in `.github/workflows/release-test.yml` and `.github/workflows/release.yml`. [[1]](diffhunk://#diff-cfb5fad94da0d964cbd2b402415839cc0c8e79a9ce5ae58586f5c8becb0d938dL77-R80) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L93-R96)

These updates ensure the workflows use the latest features and security patches provided by GitHub and the respective action maintainers.